### PR TITLE
Doc: Organization name change

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Protacon
+Copyright (c) 2020 Pinja
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ Simple usage example
 
 [The MIT License (MIT)](LICENSE)
 
-Copyright (c) 2020 Protacon
+Copyright (c) 2020 [Pinja](https://www.pinja.com)

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "lint": "ng lint",
     "e2e": "ng e2e"
   },
-  "author": "Protacon",
+  "author": "Pinja",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/protacon/ngx-resource-calendar/issues"
+    "url": "https://github.com/by-pinja/ngx-resource-calendar/issues"
   },
   "dependencies": {
     "@angular/animations": "~8.2.14",


### PR DESCRIPTION
Nowadays we're Pinja, so changed all those old "Protacon" texts on those parts that we can change before we actually rename our organization on npmjs registry.